### PR TITLE
Use a reasonable fallback for LLVM_CONF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,19 @@ cmake_minimum_required(VERSION 3.14.5)
 project(cgrep VERSION 1.1)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
-set(LLVM_CONF llvm-config-10 CACHE STRING "set the actual name of llvm-config, i.e. llvm-config-10")
+set(LLVM_CONF "" CACHE STRING "set the actual name of llvm-config, i.e. llvm-config-10")
+
+set(LLVM_CONF_TMP "${LLVM_CONF}")
+unset(LLVM_CONF CACHE)
+
+if(LLVM_CONF_TMP STREQUAL "")
+  # If LLVM_CONF wasn't provided, search for it.
+  find_program(LLVM_CONF NAMES llvm-config llvm-config-12 llvm-config-11 llvm-config-10 REQUIRED)
+else()
+  # If LLVM_CONF was provided, check if the executable actually exists.
+  find_program(LLVM_CONF NAMES "${LLVM_CONF_TMP}" REQUIRED)
+endif()
+unset(LLVM_CONF_TMP)
 
 function(CleanMessage)
   execute_process(COMMAND ${CMAKE_COMMAND} -E echo "${ARGN}")


### PR DESCRIPTION
In #19 I wrote that I couldn't compile the code via

    $ cmake -B build -S cgrep/ -DUSE_MONOLITH_LIBTOOLING=ON -DCMAKE_CXX_COMPILER=clang++
    $ cmake --build build

This is because I didn't set LLVM_CONF and it falls back to
llvm-config-10. There are two problems with this:

First, CMake didn't actually check if LLVM_CONF existed. I now check it
via the REQUIRED argument in find_program.

Second, my OS (Arch Linux) doesn't name the binary like llvm-config-10
but it's called llvm-config, so the fallback never works on Arch. Thus,
I added a non-complete but somewhat reasonable list of possible names.